### PR TITLE
fix: CIのsecretsの設定

### DIFF
--- a/.github/workflows/build_github_page.yml
+++ b/.github/workflows/build_github_page.yml
@@ -14,6 +14,8 @@ on:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+env:
+  MICROCMS_APIKEY: ${{secrets.MICROCMS_APIKEY}} 
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:


### PR DESCRIPTION
# 概要
- Github Action上で.envの環境変数が使用できないため、secretsを使用する

# 参考情報
https://docs.github.com/ja/actions/security-guides/encrypted-secrets