### PR TITLE
fix: date-fnsでtimezoneを指定する

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@mui/styled-engine-sc": "^5.12.0",
         "@tanstack/router": "^0.0.1-beta.99",
         "date-fns": "^2.30.0",
+        "date-fns-tz": "^2.0.0",
         "gatsby": "^5.11.0",
         "gatsby-plugin-force-file-loader": "^5.0.1",
         "gatsby-plugin-react-svg": "^3.3.0",
@@ -7191,6 +7192,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-2.0.0.tgz",
+      "integrity": "sha512-OAtcLdB9vxSXTWHdT8b398ARImVwQMyjfYGkKD2zaGpHseG2UPHbHjXELReErZFxWdSLph3c2zOaaTyHfOhERQ==",
+      "peerDependencies": {
+        "date-fns": ">=2.0.0"
       }
     },
     "node_modules/debug": {
@@ -23259,6 +23268,12 @@
       "requires": {
         "@babel/runtime": "^7.21.0"
       }
+    },
+    "date-fns-tz": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-2.0.0.tgz",
+      "integrity": "sha512-OAtcLdB9vxSXTWHdT8b398ARImVwQMyjfYGkKD2zaGpHseG2UPHbHjXELReErZFxWdSLph3c2zOaaTyHfOhERQ==",
+      "requires": {}
     },
     "debug": {
       "version": "3.2.7",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@mui/styled-engine-sc": "^5.12.0",
     "@tanstack/router": "^0.0.1-beta.99",
     "date-fns": "^2.30.0",
+    "date-fns-tz": "^2.0.0",
     "gatsby": "^5.11.0",
     "gatsby-plugin-force-file-loader": "^5.0.1",
     "gatsby-plugin-react-svg": "^3.3.0",

--- a/src/features/blogs/components/DateText.tsx
+++ b/src/features/blogs/components/DateText.tsx
@@ -1,5 +1,5 @@
 import Typography from "@mui/material/Typography";
-import { format } from "date-fns";
+import { formatInTimeZone } from "date-fns-tz";
 import React from "react";
 
 type Props = {
@@ -12,7 +12,7 @@ function DateText(props: Props) {
 
   return (
     <Typography variant="body2" color="text.secondary">
-      {label}: {format(date, "yyyy/MM/dd")}
+      {label}: {formatInTimeZone(date, "Asia/Tokyo", "yyyy/MM/dd")}
     </Typography>
   );
 }


### PR DESCRIPTION
# 概要
- ビルド時とクライアントのtimezoneが異なる場合でも#20のerrorが発生するとのことなので、試してみる

# 参考情報 
- https://zenn.dev/oppara/articles/jst-format-with-date-fns-tz
- https://github.com/vercel/next.js/issues/37489