### PR TITLE
blog: 【備忘録 Github Action】mainブランチ以外ではCIのみ行い、mainブランチマージ時にCDを行う記事の作成

### DIFF
--- a/content/blog/github_action_trriger.md
+++ b/content/blog/github_action_trriger.md
@@ -1,0 +1,9 @@
+---
+title: 【備忘録 Github Action】mainブランチ以外ではCIのみ行い、mainブランチマージ時にCDを行う
+description: mainブランチ以外ではCIのみ行い、mainブランチマージ時にCDを行うGithub Actionの設定
+date: "2023-08-15T00:0:00.000Z"
+category: Github  Action
+tags: ["Github Action","CI/CD",]
+---
+
+# 概要


### PR DESCRIPTION
# 概要
- 表題の通り